### PR TITLE
Implement bitwise operators

### DIFF
--- a/IL2X.Core/ASMHelpers.cs
+++ b/IL2X.Core/ASMHelpers.cs
@@ -20,13 +20,16 @@ namespace IL2X.Core
 
 		// arithmatic
 		Add,
+		Sub,		
+		Mul,
+		Div,
 		BitwiseAnd,
 		BitwiseOr,
 		BitwiseXor,
 		BitwiseNot,
-		Sub,		
-		Mul,
-		Div,
+		ShiftLeft,
+		ShiftRight,
+		ShiftRightUnsigned,
 
 		// writes
 		WriteLocal,

--- a/IL2X.Core/ASMHelpers.cs
+++ b/IL2X.Core/ASMHelpers.cs
@@ -20,7 +20,11 @@ namespace IL2X.Core
 
 		// arithmatic
 		Add,
-		Sub,
+		BitwiseAnd,
+		BitwiseOr,
+		BitwiseXor,
+		BitwiseNot,
+		Sub,		
 		Mul,
 		Div,
 
@@ -48,7 +52,7 @@ namespace IL2X.Core
 		CmpLess_1_0,
 
 		// invoke
-		CallMethod
+		CallMethod,
 	}
 
 	public class ASMObject

--- a/IL2X.Core/Emitters/Emmiter_C.cs
+++ b/IL2X.Core/Emitters/Emmiter_C.cs
@@ -488,6 +488,30 @@ namespace IL2X.Core.Emitters
 					return $"{GetOperationValue(arithmaticOp.value1)} + {GetOperationValue(arithmaticOp.value2)}";
 				}
 
+				case ASMCode.BitwiseAnd: 
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"{GetOperationValue(arithmaticOp.value1)} & {GetOperationValue(arithmaticOp.value2)}";	
+				}
+				
+				case ASMCode.BitwiseOr: 
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"{GetOperationValue(arithmaticOp.value1)} | {GetOperationValue(arithmaticOp.value2)}";	
+				}
+				
+				case ASMCode.BitwiseXor: 
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"{GetOperationValue(arithmaticOp.value1)} ^ {GetOperationValue(arithmaticOp.value2)}";	
+				}
+				
+				case ASMCode.BitwiseNot:
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"~{GetOperationValue(arithmaticOp.value1)}";
+				}
+
 				case ASMCode.Sub:
 				{
 					var arithmaticOp = (ASMArithmatic)op;

--- a/IL2X.Core/Emitters/Emmiter_C.cs
+++ b/IL2X.Core/Emitters/Emmiter_C.cs
@@ -512,6 +512,26 @@ namespace IL2X.Core.Emitters
 					return $"~{GetOperationValue(arithmaticOp.value1)}";
 				}
 
+				case ASMCode.ShiftLeft: 
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"{GetOperationValue(arithmaticOp.value1)} << {GetOperationValue(arithmaticOp.value2)}";
+				}
+				
+				//NOTE: this is an arithmetic shift right
+				case ASMCode.ShiftRight: 
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"{GetOperationValue(arithmaticOp.value1)} >> {GetOperationValue(arithmaticOp.value2)}";
+				}
+				
+				//NOTE: this is a logical shift right
+				case ASMCode.ShiftRightUnsigned: 
+				{
+					var arithmaticOp = (ASMArithmatic)op;
+					return $"{GetOperationValue(arithmaticOp.value1)} >> {GetOperationValue(arithmaticOp.value2)}";
+				}
+
 				case ASMCode.Sub:
 				{
 					var arithmaticOp = (ASMArithmatic)op;

--- a/IL2X.Core/Jit/MethodJit.cs
+++ b/IL2X.Core/Jit/MethodJit.cs
@@ -216,6 +216,39 @@ namespace IL2X.Core.Jit
 						break;
 					}
 
+					case Code.Shl: 
+					{
+						var shiftAmount = StackPop();
+						var value       = StackPop();
+						var evalVarType = GetArithmaticResultType(value.obj);
+						var evalVar     = GetEvalStackVar(evalVarType);
+						AddASMOp(new ASMArithmatic(ASMCode.ShiftLeft, OperandToASMOperand(value.obj), OperandToASMOperand(shiftAmount.obj), evalVar));
+						StackPush(op, evalVar);
+						break;
+					}
+					
+					case Code.Shr: 
+					{
+						var shiftAmount = StackPop();
+						var value       = StackPop();
+						var evalVarType = GetArithmaticResultType(value.obj);
+						var evalVar     = GetEvalStackVar(evalVarType);
+						AddASMOp(new ASMArithmatic(ASMCode.ShiftRight, OperandToASMOperand(value.obj), OperandToASMOperand(shiftAmount.obj), evalVar));
+						StackPush(op, evalVar);
+						break;
+					}
+					
+					case Code.Shr_Un: 
+					{
+						var shiftAmount = StackPop();
+						var value       = StackPop();
+						var evalVarType = GetArithmaticResultType(value.obj);
+						var evalVar     = GetEvalStackVar(evalVarType);
+						AddASMOp(new ASMArithmatic(ASMCode.ShiftRightUnsigned, OperandToASMOperand(value.obj), OperandToASMOperand(shiftAmount.obj), evalVar));
+						StackPush(op, evalVar);
+						break;
+					}
+
 					// ===================================
 					// loads
 					// ===================================

--- a/IL2X.Core/Jit/MethodJit.cs
+++ b/IL2X.Core/Jit/MethodJit.cs
@@ -138,6 +138,51 @@ namespace IL2X.Core.Jit
 						break;
 					}
 
+					case Code.And: 
+					{
+						var p2 = StackPop();
+						var p1 = StackPop();
+						var evalVarType = GetArithmaticResultType(p1.obj, p2.obj);
+						var evalVar = GetEvalStackVar(evalVarType);
+						AddASMOp(new ASMArithmatic(ASMCode.BitwiseAnd, OperandToASMOperand(p1.obj), OperandToASMOperand(p2.obj), evalVar));
+						StackPush(op, evalVar);
+						break;
+					}
+
+					case Code.Not: 
+					{
+						var p1 = StackPop();
+
+						var evalVar = GetEvalStackVar(GetArithmaticResultType(p1.obj));
+						
+						AddASMOp(new ASMArithmatic(ASMCode.BitwiseNot, OperandToASMOperand(p1.obj), null, evalVar));
+						StackPush(op, evalVar);
+						break;
+						
+					}
+
+					case Code.Or: 
+					{
+						var p2 = StackPop();
+						var p1 = StackPop();
+						var evalVarType = GetArithmaticResultType(p1.obj, p2.obj);
+						var evalVar = GetEvalStackVar(evalVarType);
+						AddASMOp(new ASMArithmatic(ASMCode.BitwiseOr, OperandToASMOperand(p1.obj), OperandToASMOperand(p2.obj), evalVar));
+						StackPush(op, evalVar);
+						break;
+					}
+					
+					case Code.Xor: 
+					{
+						var p2 = StackPop();
+						var p1 = StackPop();
+						var evalVarType = GetArithmaticResultType(p1.obj, p2.obj);
+						var evalVar = GetEvalStackVar(evalVarType);
+						AddASMOp(new ASMArithmatic(ASMCode.BitwiseXor, OperandToASMOperand(p1.obj), OperandToASMOperand(p2.obj), evalVar));
+						StackPush(op, evalVar);
+						break;
+					}
+
 					case Code.Sub:
 					{
 						var p2 = StackPop();
@@ -673,6 +718,23 @@ namespace IL2X.Core.Jit
 			}
 		}
 
+		private TypeReference GetArithmaticResultType(object value) 
+		{
+			if (value is VariableReference value_Var) return value_Var.VariableType;
+			if (value is ParameterReference value_Param) return value_Param.ParameterType;
+			if (value is Int16) return GetTypeSystem().Int16;
+			if (value is Int32) return GetTypeSystem().Int32;
+			if (value is Int64) return GetTypeSystem().Int64;
+			if (value is UInt16) return GetTypeSystem().UInt16;
+			if (value is UInt32) return GetTypeSystem().UInt32;
+			if (value is UInt64) return GetTypeSystem().UInt64;
+			if (value is Single) return GetTypeSystem().Single;
+			if (value is Double) return GetTypeSystem().Double;
+			if (value is ASMSizeOf) return GetTypeSystem().Int32;
+			if (value is ASMEvalStackLocal local) return local.type;
+			throw new NotImplementedException("Unsupported arithmatic object: " + value.GetType().ToString());	
+		}
+
 		private TypeReference GetArithmaticResultType(object value1, object value2)
 		{
 			TypeReference GetType(object value)
@@ -688,6 +750,7 @@ namespace IL2X.Core.Jit
 				if (value is Single) return GetTypeSystem().Single;
 				if (value is Double) return GetTypeSystem().Double;
 				if (value is ASMSizeOf) return GetTypeSystem().Int32;
+				if (value is ASMEvalStackLocal local) return local.type;
 				throw new NotImplementedException("Unsupported arithmatic object: " + value.GetType().ToString());
 			}
 

--- a/RayTraceBenchmark/Program.cs
+++ b/RayTraceBenchmark/Program.cs
@@ -28,7 +28,7 @@
 		{
 			int a = Foo(123);
 			int b = 24;
-			int c = a ^ b & a | ~b;
+			int c = (a ^ b & a | ~b >> 3) << 1;
 			EXIT:;
 			if (a == 124) a = -200;
 			for (int i = 0; i != 2; ++i)

--- a/RayTraceBenchmark/Program.cs
+++ b/RayTraceBenchmark/Program.cs
@@ -27,6 +27,8 @@
 		static void Main()
 		{
 			int a = Foo(123);
+			int b = 24;
+			int c = a ^ b & a | ~b;
 			EXIT:;
 			if (a == 124) a = -200;
 			for (int i = 0; i != 2; ++i)


### PR DESCRIPTION
This implements the parsing of the IL instructions
```il
    IL_000c: ldloc.0      // a
    IL_000d: ldloc.1      // b
    IL_000e: ldloc.0      // a
    IL_000f: and
    IL_0010: xor
    IL_0011: ldloc.1      // b
    IL_0012: not
    IL_0013: ldc.i4.3
    IL_0014: shr
    IL_0015: or
    IL_0016: ldc.i4.1
    IL_0017: shl
    IL_0018: stloc.2      // c
```
and the C codegen:
```c
	l_a = le_0;
	l_b = 24;
	le_1 = l_b & l_a;
	le_1 = l_a ^ le_1;
	le_1 = ~l_b;
	le_1 = le_1 >> 3;
	le_1 = le_1 | le_1;
	le_1 = le_1 << 1;
	l_c = le_1;
```